### PR TITLE
Update `cs_bc` Errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* Update default chemical shift back-calculator errors to the ones referred to in 10.1039/C9SC06561J
+
 v0.1.4 (2023-08-03)
 ------------------------------------------------------------
 

--- a/src/xeisd/clis/cli_score.py
+++ b/src/xeisd/clis/cli_score.py
@@ -286,7 +286,7 @@ def main(
             "score": result[1][score_idx],
             "avg_bc_value": result[1][avg_bc_idx],
             }
-        if type(_output[result[0]]["avg_bc_value"]) != list:
+        if type(_output[result[0]]["avg_bc_value"]) is not list:
             _output[result[0]]["avg_bc_value"] = \
                 _output[result[0]]["avg_bc_value"].tolist()
     log.info(S('done'))

--- a/src/xeisd/components/__init__.py
+++ b/src/xeisd/components/__init__.py
@@ -68,8 +68,8 @@ default_bc_errors = {
     fret_name: 0.0074,
     rh_name: 0.812,
     rdc_name: 0.88,
-    # cs error reported from UCBShift
-    cs_name: {'C': 1.31, 'CA': 0.97, 'CB': 1.29, 'H': 0.38, 'HA': 0.29},
+    # cs error reported from UCBShift, units are in ppm
+    cs_name: {'C': 0.84, 'CA': 0.81, 'CB': 1.00, 'H': 0.31, 'HA': 0.19, 'N': 1.81},  # noqa: E501
     jc_name: {'A': np.sqrt(0.14), 'B': np.sqrt(0.03), 'C': np.sqrt(0.08)},
     }
 jc_bc_mu = {'A': 6.51, 'B': -1.76, 'C': 1.6}


### PR DESCRIPTION
Noticed there was missing backbone Nitrogen errors, crossref'd [10.1039/C9SC06561J](https://doi.org/10.1039/C9SC06561J) and noticed errors were wrong. Updated default chemical shift back-calculator errors to those reported in the UCBShift paper.